### PR TITLE
Subject numbers searchable with 0-4 prefix letters

### DIFF
--- a/client/searchPage.js
+++ b/client/searchPage.js
@@ -1,7 +1,7 @@
 // Main.js
 // events and helpers for queryDisplay and courseDisplay templates
-Template.queryDisplay.helpers( 
-    {
+
+Template.queryDisplay.helpers( {
         "queryResults": function() {
             var queryResults = Session.get("queryResults");
             return queryResults || [];
@@ -9,8 +9,9 @@ Template.queryDisplay.helpers(
     }
 );
 
-Template.courseDisplay.helpers(
-    {
+Template.courseDisplay.helpers( {
+
+        // Adds the subject_with_number field to the classes objects
         "augmentedClasses": function() {
             var outerThis = this;
             return _.map( outerThis.classes, 
@@ -22,8 +23,7 @@ Template.courseDisplay.helpers(
     }
 );
 
-Template.planLayout.helpers( 
-    {
+Template.planLayout.helpers( {
 
         "slots": function() {
             var plan = Session.get("slots");
@@ -32,8 +32,8 @@ Template.planLayout.helpers(
     }
 );
 
-Template.slotDisplay.helpers(
-    {
+Template.slotDisplay.helpers( {
+        
         "slotNumber": function() {
             var slots = Session.get("slots") || [];
             var nextSlot = slots.length + 1;
@@ -41,24 +41,20 @@ Template.slotDisplay.helpers(
         },
 
         "selectedOrEmpty": function() {
+            var result = "";
             var slotSelected = Session.get("slotSelected");
             var slots = Session.get("slots") || [];
 
-            if (slotSelected === this.index ||
-                (this.index === undefined && 
-                 slotSelected === slots.length))
-            {
-                return "selected";
+            if (slotSelected === this.index || (this.index === undefined && slotSelected === slots.length)) {
+                result = "selected";
             }
-            else {
-                return "";
-            }
+
+            return result;
         }
     }
 );
 
-Template.queryPage.events (
-    {
+Template.queryPage.events ( {
         "keyup #query": function() {
             // Clear timout if there is a pending query
             var handler = Session.get("timeoutHander");
@@ -122,7 +118,7 @@ Template.queryPage.events (
 
             // recalculate slot number in case an upper slot was removed
             _.each(slots, function(slot, index) {
-                slot.index= index;
+                slot.index = index;
             });
 
             Session.set("slots", slots);

--- a/collections/courses.js
+++ b/collections/courses.js
@@ -69,11 +69,12 @@ Scheduler.Courses.QueryBuilder = {
 
     queryForTokens: function(tokens) {
 
-        var groupedTokens =_.groupBy(tokens, 'type');
+        var groupedTokens = _.groupBy(tokens, 'type');
 
         _.each(groupedTokens, function(tokenGroup, type, obj) {
             obj[type] = _.pluck(tokenGroup, 'value');
         });
+
 
         var queryObject = {};
 
@@ -94,7 +95,6 @@ Scheduler.Courses.QueryBuilder = {
 
 Scheduler.Courses.QuerySearcher = {
 
-
     resultsForQuery: function(query) {
         if (_.isEmpty(query)) return [];
         else return CoursesModel.find( query ).fetch();
@@ -106,15 +106,15 @@ Scheduler.Courses.QuerySearcher = {
 Scheduler.Courses.QueryToken = {
 
     Type: {
-        SUBJECT: 0,
-        PROFESSOR: 1,
-        TITLE: 2,
+        SUBJECT:    0,
+        PROFESSOR:  1,
+        TITLE:      2,
         DEPARTMENT: 3,
-        TIME: 4,
-        DAY: 5,
-        GE: 6,
-        NUMBER: 7,
-        UNITS: 8
+        TIME:       4,
+        DAY:        5,
+        GE:         6,
+        NUMBER:     7,
+        UNITS:      8
     },
 
 
@@ -123,6 +123,8 @@ Scheduler.Courses.QueryToken = {
 
         stringMatchesTypes: function(str) {
             var outerThis = this;
+
+            // Apply the types of each token
             return _.chain(Scheduler.Courses.QueryToken.Type)
                 .values()
                 .sortBy('valueOf')
@@ -181,7 +183,7 @@ Scheduler.Courses.QueryToken = {
         },
 
         isSubjectWithNumber: function(str) {
-            return /^[a-z]{2,4}\s?[0-9]{3}[a-z]*$/i.test(str);
+            return /^[a-z]{0,4}\s?[0-9]{3}[a-z]*$/i.test(str);
         }
     },
 
@@ -300,7 +302,7 @@ Scheduler.Courses.QueryToken = {
         },
 
         numberValueMap: function(str) {
-            return str.toUpperCase().replace(' ', '');
+            return RegExp('[A-Z]{2,4}' + str.toUpperCase().replace(' ', '') );
         }
     }
 

--- a/collections/courses.js
+++ b/collections/courses.js
@@ -302,7 +302,7 @@ Scheduler.Courses.QueryToken = {
         },
 
         numberValueMap: function(str) {
-            return RegExp('[A-Z]{2,4}' + str.toUpperCase().replace(' ', '') );
+            return RegExp( str.toUpperCase().replace(' ', '') );
         }
     }
 


### PR DESCRIPTION
Fixed issue #18.

Allows subject numbers to be searchable when prefixed by up to 0-4 letters. 

There should be some more testing to make sure this change does not invalidate other search results before this is added to master.